### PR TITLE
fix(#20): changing header font

### DIFF
--- a/src/utils/typography.js
+++ b/src/utils/typography.js
@@ -20,13 +20,13 @@ Wordpress2016.overrideThemeStyles = () => {
       fontWeight: 500
     },
     "h3,h3 a" : {
-      fontFamily: 'teko',
+      fontFamily: "'antonio bold', sans-serif",
       fontWeight: 300
     },
     "h3 a" : {
-      fontFamily: 'teko',
+      fontFamily: "'antonio bold', sans-serif",
       fontWeight: 300,
-      fontSize: '1.3em'
+      fontSize: '1.1em'
     },
     "small" : {
       fontFamily: 'open sans'


### PR DESCRIPTION
The h3 font is now using the same font as webworkers website to improve readability.

It looks like this:
![image](https://user-images.githubusercontent.com/19475195/59780222-46edc400-927f-11e9-8610-abea81c585a5.png)
